### PR TITLE
Changed line of code to avoid intermittent exception in DateTimeOffset constructor

### DIFF
--- a/SecureAuth.Sdk/HmacSigningHandler.cs
+++ b/SecureAuth.Sdk/HmacSigningHandler.cs
@@ -24,7 +24,7 @@ namespace SecureAuth.Sdk
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            request.Headers.Date = new DateTimeOffset(DateTime.Now, DateTime.Now - DateTime.UtcNow);
+            request.Headers.Date = DateTimeOffset.UtcNow;
             var hash = HmacBasicAuthenticationHelper.BuildAuthorizationHeaderParameter(AppId, AppKey, request);
 
             var headerValue = Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Format("{0}:{1}", AppId, hash)));

--- a/SecureAuth.Sdk/Models/Fingerprint.cs
+++ b/SecureAuth.Sdk/Models/Fingerprint.cs
@@ -54,7 +54,7 @@ namespace SecureAuth.Sdk.Models
         public int ColorDepth { get; set; }
 
         [DataMember(Name = "pixelRatio", EmitDefaultValue = false)]
-        public int PixelRatio { get; set; }
+        public double PixelRatio { get; set; }
 
         [DataMember(Name = "screenResolution", EmitDefaultValue = false)]
         public string ScreenResolution { get; set; }


### PR DESCRIPTION
In testing with this code I've found that the DateTimeOffset constructor will occasionally throw the unhandled exception described in this post: https://stackoverflow.com/questions/36255821/datetimeoffset-error-utc-offset-of-local-datetime-does-not-match-the-offset-arg/36255983 .  To avoid this intermittent unhandled exception, I've changed the line of code to use DateTimeOffset.UtcNow instead of the DateTimeOffset constructor.

*EDITED 7/17/2019*
Did a second commit to fix an unrelated bug where PixelRatio was defined as an integer instead of a floating-point type.